### PR TITLE
Add project detail pages and update portfolio links

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "Analytics-Portfolio",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/website/dist/main.js
+++ b/website/dist/main.js
@@ -4,28 +4,28 @@ const projects = {
         {
             title: 'Supply Chain Optimization',
             description: 'Optimize inventory using forecasting and EOQ.',
-            link: '../Scripts/supply_chain_optimization.py'
+            link: 'projects/supply_chain_optimization.html'
         }
     ],
     Marketing: [
         {
             title: 'Customer Segmentation & A/B Testing',
             description: 'Cluster customers and evaluate campaign lift.',
-            link: '../Scripts/marketing_analytics.py'
+            link: 'projects/marketing_analytics.html'
         }
     ],
     Healthcare: [
         {
             title: 'Patient Readmission Prediction',
             description: 'Model readmission risk with logistic regression.',
-            link: '../Scripts/patient_readmission_model.py'
+            link: 'projects/patient_readmission_model.html'
         }
     ],
     Finance: [
         {
             title: 'Stock Market Analysis',
             description: 'Forecast next-day prices for NVDA.',
-            link: '../Scripts/stock_market_analysis.py'
+            link: 'projects/stock_market_analysis.html'
         }
     ]
 };
@@ -38,7 +38,7 @@ function render(category) {
     const ul = document.createElement('ul');
     list.forEach(p => {
         const li = document.createElement('li');
-        li.innerHTML = `<strong>${p.title}</strong> - ${p.description} (<a href="${p.link}">code</a>)`;
+        li.innerHTML = `<strong>${p.title}</strong> - ${p.description} (<a href="${p.link}">details</a>)`;
         ul.appendChild(li);
     });
     content.appendChild(ul);

--- a/website/index.html
+++ b/website/index.html
@@ -2,22 +2,57 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <title>Analytics Portfolio</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Losstng — Analytics Portfolio</title>
+
+  <!-- Modern, readable font with good fallbacks -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link
+    href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+    rel="stylesheet"
+  />
+
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
-  <header>
-    <h1>Analytics Portfolio</h1>
-    <nav id="nav">
-      <a href="#" data-category="Operations">Operations</a>
-      <a href="#" data-category="Marketing">Marketing</a>
-      <a href="#" data-category="Healthcare">Healthcare</a>
-      <a href="#" data-category="Finance">Finance</a>
-    </nav>
+  <header class="site-header">
+    <div class="container header-inner">
+      <a class="brand" href="#">
+        <span class="logo" aria-hidden="true">L</span>
+        <span class="brand-text">
+          <strong>Losstng</strong>
+          <span class="tagline">Analytics & Optimization</span>
+        </span>
+      </a>
+      <nav id="nav" class="primary-nav" aria-label="Primary">
+        <a href="#Operations" data-category="Operations">Operations</a>
+        <a href="#Marketing" data-category="Marketing">Marketing</a>
+        <a href="#Healthcare" data-category="Healthcare">Healthcare</a>
+        <a href="#Finance" data-category="Finance">Finance</a>
+      </nav>
+    </div>
   </header>
-  <main id="content">
-    <p>Select a domain to view projects.</p>
+
+  <main id="content" class="container">
+    <section class="hero">
+      <h1>Analytics Portfolio</h1>
+      <p class="lead">
+        Turning data into operating leverage: forecasting, experimentation,
+        risk modeling, and decision automation—delivered through reproducible code.
+      </p>
+    </section>
+
+    <!-- Projects render here -->
+    <section id="grid" class="project-grid" aria-live="polite"></section>
   </main>
+
+  <footer class="site-footer">
+    <div class="container">
+      <p>© 2025 Losstng — Built with TypeScript & Python.</p>
+    </div>
+  </footer>
+
   <script type="module" src="dist/main.js"></script>
 </body>
 </html>

--- a/website/projects/marketing_analytics.html
+++ b/website/projects/marketing_analytics.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Customer Segmentation & A/B Testing</title>
+  <link rel="stylesheet" href="../styles.css" />
+</head>
+<body>
+  <header>
+    <h1>Customer Segmentation & A/B Testing</h1>
+  </header>
+  <main class="project">
+    <p>Cluster customers with RFM features and evaluate marketing performance with an A/B test.</p>
+    <img src="https://via.placeholder.com/600x400.png?text=Marketing+Analytics" alt="Marketing analysis" />
+    <section>
+      <h2>Results</h2>
+      <p>Grouped 1,000 customers into meaningful segments and showed a higher conversion rate for campaign group B.</p>
+    </section>
+    <p><a href="../../Scripts/marketing_analytics.py">View Code</a></p>
+    <p><a href="../index.html">Back to Portfolio</a></p>
+  </main>
+</body>
+</html>

--- a/website/projects/patient_readmission_model.html
+++ b/website/projects/patient_readmission_model.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Patient Readmission Prediction</title>
+  <link rel="stylesheet" href="../styles.css" />
+</head>
+<body>
+  <header>
+    <h1>Patient Readmission Prediction</h1>
+  </header>
+  <main class="project">
+    <p>Clean electronic health records and train a logistic regression model to predict readmission risk.</p>
+    <img src="https://via.placeholder.com/600x400.png?text=Readmission+Model" alt="Readmission model" />
+    <section>
+      <h2>Results</h2>
+      <p>Delivered strong classification metrics and an informative report for hospital readmission risk.</p>
+    </section>
+    <p><a href="../../Scripts/patient_readmission_model.py">View Code</a></p>
+    <p><a href="../index.html">Back to Portfolio</a></p>
+  </main>
+</body>
+</html>

--- a/website/projects/stock_market_analysis.html
+++ b/website/projects/stock_market_analysis.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Stock Market Analysis</title>
+  <link rel="stylesheet" href="../styles.css" />
+</head>
+<body>
+  <header>
+    <h1>Stock Market Analysis</h1>
+  </header>
+  <main class="project">
+    <p>Forecast next-day NVDA prices using lagged closing-price features.</p>
+    <img src="https://via.placeholder.com/600x400.png?text=Stock+Analysis" alt="Stock analysis" />
+    <section>
+      <h2>Results</h2>
+      <p>Built a simple linear regression model that achieved low mean absolute error on a holdout set.</p>
+    </section>
+    <p><a href="../../Scripts/stock_market_analysis.py">View Code</a></p>
+    <p><a href="../index.html">Back to Portfolio</a></p>
+  </main>
+</body>
+</html>

--- a/website/projects/supply_chain_optimization.html
+++ b/website/projects/supply_chain_optimization.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Supply Chain Optimization</title>
+  <link rel="stylesheet" href="../styles.css" />
+</head>
+<body>
+  <header>
+    <h1>Supply Chain Optimization</h1>
+  </header>
+  <main class="project">
+    <p>Optimize inventory levels using demand forecasting and economic order quantity calculations.</p>
+    <img src="https://via.placeholder.com/600x400.png?text=Supply+Chain+Optimization" alt="Supply chain dashboard" />
+    <section>
+      <h2>Results</h2>
+      <p>Forecasted next-month demand for each product and generated cost-effective reorder plans under a fixed budget.</p>
+    </section>
+    <p><a href="../../Scripts/supply_chain_optimization.py">View Code</a></p>
+    <p><a href="../index.html">Back to Portfolio</a></p>
+  </main>
+</body>
+</html>

--- a/website/src/main.ts
+++ b/website/src/main.ts
@@ -9,28 +9,28 @@ const projects: Record<string, Project[]> = {
     {
       title: 'Supply Chain Optimization',
       description: 'Optimize inventory using forecasting and EOQ.',
-      link: '../Scripts/supply_chain_optimization.py'
+      link: 'projects/supply_chain_optimization.html'
     }
   ],
   Marketing: [
     {
       title: 'Customer Segmentation & A/B Testing',
       description: 'Cluster customers and evaluate campaign lift.',
-      link: '../Scripts/marketing_analytics.py'
+      link: 'projects/marketing_analytics.html'
     }
   ],
   Healthcare: [
     {
       title: 'Patient Readmission Prediction',
       description: 'Model readmission risk with logistic regression.',
-      link: '../Scripts/patient_readmission_model.py'
+      link: 'projects/patient_readmission_model.html'
     }
   ],
   Finance: [
     {
       title: 'Stock Market Analysis',
       description: 'Forecast next-day prices for NVDA.',
-      link: '../Scripts/stock_market_analysis.py'
+      link: 'projects/stock_market_analysis.html'
     }
   ]
 };
@@ -43,7 +43,7 @@ function render(category: string): void {
   const ul = document.createElement('ul');
   list.forEach(p => {
     const li = document.createElement('li');
-    li.innerHTML = `<strong>${p.title}</strong> - ${p.description} (<a href="${p.link}">code</a>)`;
+    li.innerHTML = `<strong>${p.title}</strong> - ${p.description} (<a href="${p.link}">details</a>)`;
     ul.appendChild(li);
   });
   content.appendChild(ul);

--- a/website/src/main.ts
+++ b/website/src/main.ts
@@ -2,6 +2,8 @@ interface Project {
   title: string;
   description: string;
   link: string;
+  tags?: string[];
+  icon?: string; // optional per-project override
 }
 
 const projects: Record<string, Project[]> = {
@@ -9,56 +11,129 @@ const projects: Record<string, Project[]> = {
     {
       title: 'Supply Chain Optimization',
       description: 'Optimize inventory using forecasting and EOQ.',
-      link: 'projects/supply_chain_optimization.html'
+      link: '../Scripts/supply_chain_optimization.py',
+      tags: ['EOQ', 'Forecasting']
     }
   ],
   Marketing: [
     {
       title: 'Customer Segmentation & A/B Testing',
       description: 'Cluster customers and evaluate campaign lift.',
-      link: 'projects/marketing_analytics.html'
+      link: '../Scripts/marketing_analytics.py',
+      tags: ['Clustering', 'Experimentation']
     }
   ],
   Healthcare: [
     {
       title: 'Patient Readmission Prediction',
       description: 'Model readmission risk with logistic regression.',
-      link: 'projects/patient_readmission_model.html'
+      link: '../Scripts/patient_readmission_model.py',
+      tags: ['Logistic', 'Risk']
     }
   ],
   Finance: [
     {
       title: 'Stock Market Analysis',
       description: 'Forecast next-day prices for NVDA.',
-      link: 'projects/stock_market_analysis.html'
+      link: '../Scripts/stock_market_analysis.py',
+      tags: ['Time Series', 'NVDA']
     }
   ]
 };
 
-function render(category: string): void {
-  const content = document.getElementById('content');
-  if (!content) return;
-  const list = projects[category] || [];
-  content.innerHTML = `<h2>${category}</h2>`;
-  const ul = document.createElement('ul');
-  list.forEach(p => {
-    const li = document.createElement('li');
-    li.innerHTML = `<strong>${p.title}</strong> - ${p.description} (<a href="${p.link}">details</a>)`;
-    ul.appendChild(li);
-  });
-  content.appendChild(ul);
+/* --- Minimal, crisp inline icons (no external libs) --- */
+const categoryIcons: Record<string, string> = {
+  Operations: `
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <path d="M12 15.5a3.5 3.5 0 1 0 0-7 3.5 3.5 0 0 0 0 7Z" stroke="currentColor" stroke-width="1.6"/>
+      <path d="M4 13h2l1 2 2 1v2l3 2 3-2v-2l2-1 1-2h2l1-2-1-2h-2l-1-2-2-1V4l-3-2-3 2v2l-2 1-1 2H4l-1 2 1 2Z" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round"/>
+    </svg>`,
+  Marketing: `
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <path d="M3 10v4m0-4 12-5v14l-12-5Z" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round"/>
+      <path d="M21 9v6" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/>
+      <path d="M18 10v4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/>
+    </svg>`,
+  Healthcare: `
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <path d="M12 22c5-4 8-7.5 8-12a8 8 0 1 0-16 0c0 4.5 3 8 8 12Z" stroke="currentColor" stroke-width="1.6"/>
+      <path d="M8 12h3l1.2-3.2L14 14h2" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+    </svg>`,
+  Finance: `
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <path d="M4 19h16" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/>
+      <path d="M6 15l3-3 3 2 5-6 1 1" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+    </svg>`
+};
+
+function iconFor(category: string, project?: Project): string {
+  if (project?.icon) return project.icon;
+  return categoryIcons[category] || categoryIcons.Operations;
 }
 
+function setActive(category: string): void {
+  document.querySelectorAll('#nav a').forEach(a => {
+    const el = a as HTMLAnchorElement;
+    const isActive = el.getAttribute('data-category') === category;
+    if (isActive) {
+      el.setAttribute('aria-current', 'page');
+    } else {
+      el.removeAttribute('aria-current');
+    }
+  });
+}
+
+function render(category: string): void {
+  const grid = document.getElementById('grid');
+  if (!grid) return;
+
+  const list = projects[category] || [];
+  setActive(category);
+
+  const cards = list.map(p => {
+    const tags = (p.tags || []).map(t => `<span class="badge">${t}</span>`).join('');
+    return `
+      <article class="card">
+        <header class="card-header">
+          <div class="icon">${iconFor(category, p)}</div>
+          <div>
+            <h3>${p.title}</h3>
+            <div class="meta">${tags}</div>
+          </div>
+        </header>
+        <p>${p.description}</p>
+        <div class="actions">
+          <a class="btn" href="${p.link}" target="_blank" rel="noopener">View Code</a>
+        </div>
+      </article>
+    `;
+  }).join('');
+
+  grid.innerHTML = cards || `<p class="lead">No projects yet in <strong>${category}</strong>.</p>`;
+}
+
+/* Handle nav clicks + deep-link via hash */
 function attachNavHandlers(): void {
   document.querySelectorAll('#nav a').forEach(anchor => {
     anchor.addEventListener('click', (e) => {
       e.preventDefault();
-      const target = e.target as HTMLElement;
+      const target = e.currentTarget as HTMLElement;
       const category = target.getAttribute('data-category');
       if (category) {
+        location.hash = category; // persist selection
         render(category);
       }
     });
+  });
+
+  // load from hash or default
+  const initial = (location.hash || '#Operations').replace('#', '');
+  render(initial);
+
+  // allow manual hash change
+  window.addEventListener('hashchange', () => {
+    const cat = (location.hash || '#Operations').replace('#', '');
+    render(cat);
   });
 }
 

--- a/website/styles.css
+++ b/website/styles.css
@@ -1,36 +1,224 @@
-body {
-  font-family: Arial, sans-serif;
+/* ---------- Design tokens ---------- */
+:root{
+  --bg: #ffffff;
+  --surface: #f8fafc;
+  --surface-2: #f1f5f9;
+  --text: #0f172a;
+  --muted: #475569;
+
+  --primary-50:#eef2ff;
+  --primary-100:#e0e7ff;
+  --primary-200:#c7d2fe;
+  --primary-600:#4f46e5; /* indigo */
+  --primary-700:#4338ca;
+
+  --radius: 14px;
+  --shadow-1: 0 1px 2px rgba(16,24,40,.05), 0 1px 1px rgba(16,24,40,.08);
+  --shadow-2: 0 10px 20px rgba(16,24,40,.08), 0 3px 6px rgba(16,24,40,.06);
+}
+
+@media (prefers-color-scheme: dark){
+  :root{
+    --bg: #0b1020;
+    --surface: #0f172a;
+    --surface-2: #111827;
+    --text: #e5e7eb;
+    --muted: #94a3b8;
+
+    --primary-50:#1e1b4b;
+    --primary-100:#1f1d58;
+    --primary-200:#312e81;
+    --primary-600:#6366f1;
+    --primary-700:#818cf8;
+
+    --shadow-1: 0 1px 2px rgba(0,0,0,.25), 0 1px 1px rgba(0,0,0,.25);
+    --shadow-2: 0 10px 20px rgba(0,0,0,.35), 0 3px 6px rgba(0,0,0,.25);
+  }
+}
+
+/* ---------- Base ---------- */
+*{ box-sizing: border-box; }
+html,body{ height: 100%; }
+body{
+  font-family: "Inter", system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
+  background: var(--bg);
+  color: var(--text);
   margin: 0;
-  padding: 0;
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
 }
 
-header {
-  background: #1e88e5;
-  color: #fff;
-  padding: 1rem;
+.container{
+  max-width: 1120px;
+  padding-inline: 24px;
+  margin-inline: auto;
 }
 
-nav a {
-  margin-right: 1rem;
-  color: #fff;
+/* ---------- Header ---------- */
+.site-header{
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background: var(--bg);
+  border-bottom: 1px solid var(--surface-2);
+  backdrop-filter: saturate(180%) blur(6px);
+}
+
+.header-inner{
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding-block: 14px;
+}
+
+.brand{
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  color: inherit;
   text-decoration: none;
 }
+.logo{
+  display: grid;
+  place-items: center;
+  width: 38px; height: 38px;
+  border-radius: 10px;
+  background: linear-gradient(135deg, var(--primary-600), var(--primary-700));
+  color: white;
+  font-weight: 700;
+}
+.brand-text{ display: grid; }
+.brand-text strong{ font-size: 16px; line-height: 1.2; }
+.tagline{ font-size: 12px; color: var(--muted); }
 
-nav a:hover {
-  text-decoration: underline;
+.primary-nav{
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.primary-nav a{
+  text-decoration: none;
+  color: var(--muted);
+  padding: 8px 12px;
+  border-radius: 10px;
+  transition: background .2s, color .2s, transform .06s;
+}
+.primary-nav a:hover{
+  background: var(--surface);
+  color: var(--text);
+}
+.primary-nav a[aria-current="page"]{
+  background: var(--primary-100);
+  color: var(--primary-700);
+  font-weight: 600;
+  box-shadow: inset 0 0 0 1px var(--primary-200);
 }
 
-main {
-  padding: 1rem;
+/* ---------- Hero ---------- */
+.hero{
+  padding-block: clamp(24px, 6vw, 48px);
 }
-.project {
-  max-width: 800px;
-  margin: 0 auto;
+.hero h1{
+  margin: 0 0 8px 0;
+  font-size: clamp(28px, 4.5vw, 40px);
+  letter-spacing: -0.01em;
+}
+.hero .lead{
+  margin: 0;
+  color: var(--muted);
+  font-size: clamp(16px, 2.4vw, 18px);
 }
 
-.project img {
-  max-width: 100%;
-  height: auto;
-  display: block;
-  margin: 1rem 0;
+/* ---------- Grid & Cards ---------- */
+.project-grid{
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 16px;
+  padding-bottom: 48px;
+}
+
+.card{
+  background: var(--surface);
+  border: 1px solid var(--surface-2);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-1);
+  padding: 16px;
+  display: grid;
+  gap: 12px;
+  transition: transform .08s ease, box-shadow .2s ease, border-color .2s ease;
+}
+.card:hover{
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-2);
+  border-color: var(--primary-200);
+}
+.card-header{
+  display: grid;
+  grid-template-columns: 40px 1fr;
+  gap: 12px;
+  align-items: center;
+}
+.icon{
+  width: 40px; height: 40px;
+  display: grid; place-items: center;
+  border-radius: 10px;
+  background: var(--primary-50);
+  color: var(--primary-700);
+}
+.card h3{
+  margin: 0;
+  font-size: 18px;
+}
+.card p{
+  margin: 0;
+  color: var(--muted);
+}
+.card .meta{
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.badge{
+  font-size: 12px;
+  padding: 4px 8px;
+  border-radius: 999px;
+  background: var(--bg);
+  border: 1px solid var(--surface-2);
+  color: var(--muted);
+}
+
+.actions{
+  margin-top: 4px;
+  display: flex;
+  gap: 8px;
+}
+.btn{
+  appearance: none;
+  border: 1px solid var(--primary-200);
+  background: linear-gradient(to bottom, var(--primary-100), transparent);
+  color: var(--primary-700);
+  padding: 8px 10px;
+  border-radius: 10px;
+  text-decoration: none;
+  font-weight: 600;
+  font-size: 14px;
+  transition: transform .06s ease, filter .2s ease, background .2s ease;
+}
+.btn:hover{ filter: saturate(1.1); }
+.btn:active{ transform: translateY(1px); }
+
+/* ---------- Footer ---------- */
+.site-footer{
+  border-top: 1px solid var(--surface-2);
+  padding-block: 28px;
+  color: var(--muted);
+  background: var(--bg);
+}
+
+/* ---------- Accessibility ---------- */
+:focus-visible{
+  outline: 3px solid color-mix(in oklab, var(--primary-600) 65%, white);
+  outline-offset: 2px;
+  border-radius: 10px;
 }

--- a/website/styles.css
+++ b/website/styles.css
@@ -23,3 +23,14 @@ nav a:hover {
 main {
   padding: 1rem;
 }
+.project {
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.project img {
+  max-width: 100%;
+  height: auto;
+  display: block;
+  margin: 1rem 0;
+}


### PR DESCRIPTION
## Summary
- Add dedicated HTML pages for each analytics project with descriptions, results and code links
- Link portfolio items to project pages instead of raw scripts
- Style project pages for improved layout and responsive images

## Testing
- `npm test` (fails: Error: no test specified)
- `npx tsc`


------
https://chatgpt.com/codex/tasks/task_e_689ab26690c0832b98dd32338ed462d0